### PR TITLE
fix rounding to match example

### DIFF
--- a/SalsBreakdown/IncomeCalc/IncomeCalculator.cs
+++ b/SalsBreakdown/IncomeCalc/IncomeCalculator.cs
@@ -40,7 +40,7 @@ namespace SalsBreakdown.IncomeCalc {
         public decimal CalcSuperContibutionAmount(decimal grossPackage) {
             decimal super = this.SuperContributionPercent * grossPackage / (1 + this.SuperContributionPercent);
             //round up to nearest cent
-            return Math.Round(super, 2, MidpointRounding.AwayFromZero);
+            return Math.Round(super, 2, MidpointRounding.ToPositiveInfinity);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace SalsBreakdown.IncomeCalc {
         /// <returns></returns>
         public decimal CalcTaxableIncome(decimal grossPackage, bool forDeducations = false) {
             decimal tiValue = grossPackage - this.CalcSuperContibutionAmount(grossPackage);
-            
+
             if (forDeducations)//rounded down to the nearest dollar when calculated decuctions
                 return Math.Round(tiValue, 0, MidpointRounding.ToZero);
             else//round down to nearest cent
@@ -65,7 +65,7 @@ namespace SalsBreakdown.IncomeCalc {
         public decimal CalcPayPacket(decimal grossPackage, PayFrequency frequency, params decimal[] deductions) {
             decimal pay = this.CalcNetIncome(grossPackage, deductions) / (int)frequency;
             //round up to nearest cent
-            return Math.Round(pay, 2, MidpointRounding.AwayFromZero);
+            return Math.Round(pay, 2, MidpointRounding.ToPositiveInfinity);
         }
 
     }

--- a/SalsBreakdown/IncomeRules/Interface/TaxRule.cs
+++ b/SalsBreakdown/IncomeRules/Interface/TaxRule.cs
@@ -37,6 +37,7 @@ namespace SalsBreakdown.IncomeRules {
 
         public virtual decimal CalculateLevy(decimal taxableIncome) {
             decimal value =  (this.Amount ?? 0) + ((taxableIncome - (this.HasLowRangeOffset ? this.LowRange - 1 : 0)) * this.Percent);
+            //always round up
             return Math.Round(value, 0, MidpointRounding.ToPositiveInfinity);
         }
 

--- a/SalsBreakdown/SalsBreakdown.csproj
+++ b/SalsBreakdown/SalsBreakdown.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Utils\Round.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Utils\" />
   </ItemGroup>
 

--- a/SalsBreakdown/Utils/Round.cs
+++ b/SalsBreakdown/Utils/Round.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SalsBreakdown.Utils {
+    public class RoundHelper {
+
+        /// <summary>
+        /// Round down to precision
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="precision"></param>
+        /// <returns></returns>
+        public static decimal RoundDown(decimal value, int precision) {
+            //not the most efficient but will work
+            /*1.53 precsion 0 => 1
+             * 2.255 precision 1 => 2.2
+             * 
+             */
+            bool isNegative = value < 0;
+
+
+            decimal expanded = Math.Abs(value) * (decimal)Math.Pow(10d, (double)precision);//1.53, 22.55
+            decimal lhs = Math.Floor(expanded); //1, 22
+            decimal tmpValue = expanded - lhs; //1.53-1 = 0.53, 22.55- 22=0.55
+            expanded = tmpValue * 10;//5.3, 5.5
+            tmpValue = Math.Floor(expanded);//5.3=5, 5.5=5
+
+            if (tmpValue != 5)
+                return Math.Round(value, precision);
+            else
+                return (isNegative ? -1 : 1) * lhs / (decimal)Math.Pow(10d, (double)precision);
+
+        }
+
+    }
+}


### PR DESCRIPTION
ok. so when the thing says rounding and says the example is correct. a little reverse engineering find that it's not proper rounding e.g 1.6 to 0 precision = 2. and 1.4 to 0 precision = 1
Based on the example results we can confidently say that it's just completely ignored the 6 from the 1.6 example etc
The only example is 366.5(367) which is not helpful, because this would be rounded up either way.
Ambiguous and would get a further example of rounding behaviour before going ahead with this whole story.